### PR TITLE
refactor(back): CORS 설정 allowedmethod 추가

### DIFF
--- a/back/src/main/java/com/github/oneline/onelinecourse/configuration/WebConfig.java
+++ b/back/src/main/java/com/github/oneline/onelinecourse/configuration/WebConfig.java
@@ -11,7 +11,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:1234");
+                .allowedOrigins("http://localhost:1234")
+                .allowedMethods("*"); // default: GET, POST, HEAD
     }
 
     @Override


### PR DESCRIPTION
- 서버에서 요청을 허용하는 method는 default로 GET, POST, HEAD 임
- DELETE 메서드의 경우 CORS 정책에 의해 막힘
- 따라서 모든 method에 대해 허용하도록 설정
- 참고: https://heowc.dev/2018/03/13/spring-boot-cors/
- 참고: https://spring.io/blog/2015/06/08/cors-support-in-spring-framework